### PR TITLE
Correct url on Research Groups's example event.

### DIFF
--- a/content/event/example/index.md
+++ b/content/event/example/index.md
@@ -58,6 +58,6 @@ Slides can be added in a few ways:
 
 - **Create** slides using Wowchemy's [_Slides_](https://wowchemy.com/docs/managing-content/#create-slides) feature and link using `slides` parameter in the front matter of the talk file
 - **Upload** an existing slide deck to `static/` and link using `url_slides` parameter in the front matter of the talk file
-- **Embed** your slides (e.g. Google Slides) or presentation video on this page using [shortcodes](https://wowchemy.com/docs/writing-markdown-latex/).
+- **Embed** your slides (e.g. Google Slides) or presentation video on this page using [shortcodes](https://wowchemy.com/docs/content/writing-markdown-latex/).
 
 Further event details, including page elements such as image galleries, can be added to the body of this page.


### PR DESCRIPTION
A very small correction: the example slide has a broken link to the wowchemy manual.